### PR TITLE
chore: update install page

### DIFF
--- a/docs/introduction/installation.md
+++ b/docs/introduction/installation.md
@@ -77,7 +77,6 @@ If you're not using Portainer, you can start the service using ``docker-compose 
 
 #### Using Traefik to secure Homarr
 Copying the configuration straight from the docker-compose file won't work if you are running homarr behind Traefik, such as a Portainer setup, or docker-swarm. In that case, you should use the following slightly modified configuration:
-<br/>
 ```yaml
 version: '3'
 services:

--- a/docs/introduction/installation.md
+++ b/docs/introduction/installation.md
@@ -73,9 +73,11 @@ services:
 
 If you're not using Portainer, you can start the service using ``docker-compose up -d`` in the same directory.
 
-:::tip
-Using Traefik to secure Homarr
+<br/>
+
+#### Using Traefik to secure Homarr
 Copying the configuration straight from the docker-compose file won't work if you are running homarr behind Traefik, such as a Portainer setup, or docker-swarm. In that case, you should use the following slightly modified configuration:
+<br/>
 ```yaml
 version: '3'
 services:
@@ -101,6 +103,7 @@ networks:
   proxy:
     external: true
 ```
+<br/>
 
 A sample Traefik docker-compose.yml using Cloudflare for certificate generation that works with the configuration above would be:
 ```yaml
@@ -150,8 +153,10 @@ networks:
     external: true
 ```
 
+:::tip
 Of particular note here is that both configurations explicitly define which network they are using, in this case "proxy", but it can be named anything. It just has to be the same across all services for which Traefik is serving as a proxy. These are marked as external because the proxy network was manually created by running: `docker network create proxy` but this might be unecessary depending on HOW exactly you are running Traefik. For example, if running [Traefik with Portainer](https://docs.portainer.io/advanced/reverse-proxy/traefik#deploying-in-a-docker-standalone-scenario), you can follow their official docs on how to setup Traefik and Portainer together, and you can just focus on the homarr docker labels instead.
 :::
+
 
 ## 🛒 Install from the Unraid Community App Store
 You can install Unraid without ``docker run`` and ``docker-compose``, directly from your Unraid Web Dashboard.

--- a/docs/introduction/installation.md
+++ b/docs/introduction/installation.md
@@ -73,7 +73,8 @@ services:
 
 If you're not using Portainer, you can start the service using ``docker-compose up -d`` in the same directory.
 
-### Using Homarr behind Traefik with Portainer
+:::tip
+Using Traefik to secure Homarr
 Copying the configuration straight from the docker-compose file won't work if you are running homarr behind Traefik, such as a Portainer setup, or docker-swarm. In that case, you should use the following slightly modified configuration:
 ```yaml
 version: '3'
@@ -150,7 +151,7 @@ networks:
 ```
 
 Of particular note here is that both configurations explicitly define which network they are using, in this case "proxy", but it can be named anything. It just has to be the same across all services for which Traefik is serving as a proxy. These are marked as external because the proxy network was manually created by running: `docker network create proxy` but this might be unecessary depending on HOW exactly you are running Traefik. For example, if running [Traefik with Portainer](https://docs.portainer.io/advanced/reverse-proxy/traefik#deploying-in-a-docker-standalone-scenario), you can follow their official docs on how to setup Traefik and Portainer together, and you can just focus on the homarr docker labels instead.
-
+:::
 
 ## 🛒 Install from the Unraid Community App Store
 You can install Unraid without ``docker run`` and ``docker-compose``, directly from your Unraid Web Dashboard.

--- a/docs/introduction/installation.md
+++ b/docs/introduction/installation.md
@@ -103,6 +103,7 @@ networks:
   proxy:
     external: true
 ```
+
 <br/>
 
 A sample Traefik docker-compose.yml using Cloudflare for certificate generation that works with the configuration above would be:
@@ -152,6 +153,7 @@ networks:
   proxy:
     external: true
 ```
+
 
 :::tip
 Of particular note here is that both configurations explicitly define which network they are using, in this case "proxy", but it can be named anything. It just has to be the same across all services for which Traefik is serving as a proxy. These are marked as external because the proxy network was manually created by running: `docker network create proxy` but this might be unecessary depending on HOW exactly you are running Traefik. For example, if running [Traefik with Portainer](https://docs.portainer.io/advanced/reverse-proxy/traefik#deploying-in-a-docker-standalone-scenario), you can follow their official docs on how to setup Traefik and Portainer together, and you can just focus on the homarr docker labels instead.


### PR DESCRIPTION
### Category
Documentation

### Overview
This commit add a few examples of how to setup homarr behind a traefik proxy in a portainer/docker-compose/swarm setup. This question popped up a couple of times on the discord, so having a piece of documentation to help guide people should be helpful.
