### PR TITLE
Add precision for custom icon path in icons.md

### DIFF
--- a/docs/customizations/icons.md
+++ b/docs/customizations/icons.md
@@ -26,7 +26,12 @@ Add your icons to the icons folder. The icons should be named after the app name
 ### Using your icons
 Access the icon(s) using `/icons/name.webp` or `/icons/name.svg`.
 
+:::info
+
+Even if you mounted the icons folder in `/app/public/icons`, your custom icons should be accessed by `/icons/` directly.
+
 ![image](./img/icons/custom-icon.webp)
+
 
 :::caution
 


### PR DESCRIPTION
### Category
> Documentation 

### Overview
> Added a info section to let the user know that he will need to access his custom icons through /icons/ directly and not /app/public/icons/

I struggled for a while before understanding that my icons should be accessed by /icons/ directly.

This precision can help people to not make the same mistake I did.