### PR TITLE
📝 remove clear cache faq line

### DIFF
--- a/docs/community/faq.mdx
+++ b/docs/community/faq.mdx
@@ -28,10 +28,6 @@ Enabling users to write their own widgets is easy at the first glance, but there
 
 If you still want to add a widget, please consider to contribute it directly to Homarr. For that, basic programming skills are required. Our [Developer Guides](/docs/community/developer-guides) explain this even more detailed.
 
-### My widgets or apps are not updating, after I made changes to them.
-The Homarr caching system is most likely messing around with the update.
-Please try to clear the cache at ``Menu at the top right`` > ``Settings`` > ``Clear all cache``.
-
 ### Is it secure to expose Homarr to the web?
 
 Yes, since v0.14.0, we are confident that Homarr is secure enough to be exposed to the web. 


### PR DESCRIPTION
### Category
> Documentation

### Overview
> Remove clear cache line in FAQ as no longer relevant.
> Couldn't find other mentions of clear cache in the docs.
