### PR TITLE
Mention need to whitelist jsdelivr in DNS-Hole

### DIFF
--- a/docs/community/faq.mdx
+++ b/docs/community/faq.mdx
@@ -18,6 +18,10 @@ You can report issues, suggestions, or ideas for improvements <a href="https://g
 ### Can I use my own custom icons for apps?
 Yes, check out our guide on <a href="/docs/customizations/icons">how to add your custom icons</a>.
 
+### Some of my online icons are not working (anymore)
+It seems the `cdn.jsdelivr.net` database of icon sometimes appear in the lists for DNS-Holes (Pihole, AdGuard Home...). <br />
+So make sure to manually whitelist this address.
+
 ### Can I add my own widgets? Do I need programming skills?
 We have decided, not to support custom widgets, until Homarr is in a stable and highly polished state.
 Enabling users to write their own widgets is easy at the first glance, but there are some major issues with it:


### PR DESCRIPTION
### Category
> Documentation

### Overview
> Recently cdn.jsdelivr.net was added to one of the very commonly used adlist for dnshole and users have noticed the icons not working anymore.
> Adding this mention to whitelist the website in the FAQ alongside the other entry regarding the icons.

### Issue Number
> Made known on discord