### PR TITLE
[Docs] Fix heading typo: _category_.json

### DIFF
--- a/docs/management/_category_.json
+++ b/docs/management/_category_.json
@@ -1,4 +1,4 @@
 {
-  "label": "Managment",
+  "label": "Management",
   "position": 5
 }


### PR DESCRIPTION
### Category
Documentation

### Overview
Small typo in main heading
